### PR TITLE
Define and implement service health checks

### DIFF
--- a/observability/grafana/provisioning/alerting/contact-points.yml
+++ b/observability/grafana/provisioning/alerting/contact-points.yml
@@ -1,0 +1,31 @@
+apiVersion: 1
+contactPoints:
+  - orgId: 1
+    name: slack-primary
+    receivers:
+      - uid: slack-primary
+        type: slack
+        settings:
+          url: ${SLACK_WEBHOOK_URL}
+          username: grafana
+          recipient: ${SLACK_CHANNEL}
+          icon_emoji: ":rotating_light:"
+  - orgId: 1
+    name: pagerduty-primary
+    receivers:
+      - uid: pagerduty-primary
+        type: pagerduty
+        settings:
+          integrationKey: ${PAGERDUTY_ROUTING_KEY}
+
+notificationPolicies:
+  - orgId: 1
+    receiver: slack-primary
+    group_by: ["service", "env"]
+    matchers:
+      - { label: severity, match: =, value: warn }
+  - orgId: 1
+    receiver: pagerduty-primary
+    group_by: ["service", "env"]
+    matchers:
+      - { label: severity, match: =, value: critical }

--- a/observability/grafana/provisioning/alerting/rules.yml
+++ b/observability/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,137 @@
+groups:
+  - orgId: 1
+    name: common-log-alerts
+    folder: Observability
+    interval: 1m
+    rules:
+      - uid: error-spike
+        title: Error spike > 5 in 60s
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: loki
+            model:
+              queryType: range
+              expr: sum by (service) (count_over_time({level="error"}[1m])) > 5
+              instant: false
+        annotations:
+          severity: critical
+        labels:
+          team: platform
+          env: ${ENV}
+      - uid: health-fail-log
+        title: Health check failed log
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: loki
+            model:
+              queryType: range
+              expr: sum(count_over_time({app=~"server|worker|monitor|cron"} |= "HEALTH_CHECK_FAIL" [5m])) > 0
+              instant: false
+        annotations:
+          severity: critical
+        labels:
+          team: platform
+          env: ${ENV}
+
+  - orgId: 1
+    name: server-api
+    folder: Services
+    interval: 1m
+    rules:
+      - uid: server-5xx-rate
+        title: Server 5xx rate > 2%
+        condition: A
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              expr: |
+                sum(rate(http_requests_total{service="server",status=~"5.."}[5m]))
+                  /
+                sum(rate(http_requests_total{service="server"}[5m])) > 0.02
+              instant: false
+        annotations:
+          severity: critical
+        labels:
+          service: server
+          env: ${ENV}
+
+  - orgId: 1
+    name: worker-queues
+    folder: Services
+    interval: 1m
+    rules:
+      - uid: worker-queue-lag
+        title: Worker queue lag critical
+        condition: A
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              expr: max(queue_oldest_age_seconds{service="worker"}) > 300
+              instant: false
+        annotations:
+          severity: critical
+        labels:
+          service: worker
+          env: ${ENV}
+
+  - orgId: 1
+    name: cron-scheduler
+    folder: Services
+    interval: 1m
+    rules:
+      - uid: cron-drift
+        title: Cron scheduler drift > 5m
+        condition: A
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              expr: max(time() - cron_last_success_timestamp_seconds{job_type="critical"}) > 300
+              instant: false
+        annotations:
+          severity: critical
+        labels:
+          service: cron
+          env: ${ENV}
+
+  - orgId: 1
+    name: monitor-indexer
+    folder: Services
+    interval: 1m
+    rules:
+      - uid: monitor-rpc-down
+        title: Monitor RPC dependency down
+        condition: A
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              expr: min_over_time(dependency_up{service="monitor",name="chainRpc"}[5m]) < 1
+              instant: false
+        annotations:
+          severity: critical
+        labels:
+          service: monitor
+          env: ${ENV}

--- a/observability/health/health_spec.md
+++ b/observability/health/health_spec.md
@@ -1,0 +1,83 @@
+### Health abstraction specification
+
+This document defines a small, implementation-agnostic health abstraction and wire protocol for services to report liveness, readiness, and detailed component health, without code duplication across services.
+
+#### Endpoints
+- `/health/live`: Returns 200 when the process is alive. Should be cheap, avoid external I/O. Returns 503 when not alive.
+- `/health/ready`: Returns 200 only when all critical readiness checks pass (e.g., DB connectivity, essential dependencies). Returns 503 otherwise.
+- `/health`: Returns a structured JSON payload with detailed checks. Should return 200 with a JSON body containing overall status; optionally support `?httpStatusFromStatus=true` to also reflect status via HTTP status code: `healthy=200`, `degraded=429`, `unhealthy=503`.
+
+#### JSON schema (summary)
+- `service`: Service name (e.g., `monitor`, `cron`, `worker`, `server`).
+- `status`: One of `healthy`, `degraded`, `unhealthy`.
+- `timestamp`: RFC3339 UTC timestamp of evaluation.
+- `version`: Optional version/commit/build info.
+- `checks[]`: List of component checks:
+  - `name`: Human-friendly identifier (e.g., `database`, `queueLag`, `redis`, `chainRpc`)
+  - `componentType`: Category of dependency (e.g., `database`, `queue`, `cache`, `http`, `scheduler`, `filesystem`)
+  - `status`: `pass`, `fail`, `warn`
+  - `severity`: `critical` or `non_critical` (controls readiness gate)
+  - `observedValue`: Any JSON-serializable measurement (e.g., ms latency, queue depth)
+  - `expected`: Human-readable expectation or numeric threshold(s)
+  - `timeMs`: Duration spent in the check
+  - `output`: Optional error text for failures/warns
+- `summary`: Aggregated counts per status
+
+See `schemas/health.schema.json` for the full JSON schema.
+
+#### Aggregation rules
+- Overall `status` is computed from checks using the following precedence:
+  - If any `critical` check has `fail` -> `unhealthy`
+  - Else if any check has `warn` -> `degraded`
+  - Else -> `healthy`
+
+#### Readiness gate
+- `/health/ready` must return 503 unless all `critical` checks are `pass`.
+- Non-critical failed checks should not block readiness, but should surface in `/health` and metrics/logs.
+
+#### Common checks (shared logic)
+- `DatabaseConnectivityCheck`: Attempts a lightweight query (e.g., `SELECT 1` or ping). Times out fast.
+- `QueueLagCheck`: Measures lag or oldest message age; compares against thresholds.
+- `CacheConnectivityCheck`: PING/PONG or `SET/GET` tiny key with TTL.
+- `HttpDependencyCheck`: HEAD/GET with timeout and expected status/window.
+- `SchedulerDriftCheck` (cron): Compares now vs last successful run; warns if drift exceeds tolerance.
+- `ErrorRateCheck` (log-derived): Fails/warns based on error count in window; typically from metrics/logs, not inline.
+
+#### Minimal wire example
+```json
+{
+  "service": "server",
+  "status": "degraded",
+  "timestamp": "2025-09-15T12:00:00Z",
+  "version": { "gitSha": "abc123", "build": "2025-09-15.1" },
+  "checks": [
+    {
+      "name": "database",
+      "componentType": "database",
+      "status": "pass",
+      "severity": "critical",
+      "observedValue": { "latencyMs": 12 },
+      "expected": { "latencyMsLt": 150 },
+      "timeMs": 13
+    },
+    {
+      "name": "redis",
+      "componentType": "cache",
+      "status": "warn",
+      "severity": "non_critical",
+      "observedValue": { "latencyMs": 180 },
+      "expected": { "latencyMsLt": 100 },
+      "timeMs": 182,
+      "output": "PING slow"
+    }
+  ],
+  "summary": { "pass": 1, "warn": 1, "fail": 0 }
+}
+```
+
+#### Implementation guidance
+- Keep all common check types in a shared library to avoid duplication.
+- Services should compose the shared checks with service-specific checks.
+- Always timebox checks with short timeouts and guard against cascading failures.
+- Emit one-line logs for check failures to feed Loki alerts, e.g., `HEALTH_CHECK_FAIL service=server check=database error=...`.
+

--- a/observability/health/schemas/health.schema.json
+++ b/observability/health/schemas/health.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/health.schema.json",
+  "title": "ServiceHealthReport",
+  "type": "object",
+  "required": ["service", "status", "timestamp", "checks", "summary"],
+  "properties": {
+    "service": { "type": "string" },
+    "status": { "enum": ["healthy", "degraded", "unhealthy"] },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "version": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "componentType", "status", "severity", "timeMs"],
+        "properties": {
+          "name": { "type": "string" },
+          "componentType": {
+            "enum": [
+              "database",
+              "queue",
+              "cache",
+              "http",
+              "scheduler",
+              "filesystem",
+              "blockchain",
+              "other"
+            ]
+          },
+          "status": { "enum": ["pass", "fail", "warn"] },
+          "severity": { "enum": ["critical", "non_critical"] },
+          "observedValue": {},
+          "expected": {},
+          "timeMs": { "type": "number" },
+          "output": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["pass", "warn", "fail"],
+      "properties": {
+        "pass": { "type": "number" },
+        "warn": { "type": "number" },
+        "fail": { "type": "number" }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+

--- a/observability/health/triggers.md
+++ b/observability/health/triggers.md
@@ -1,0 +1,62 @@
+### Health triggers per service
+
+This file defines what constitutes "unhealthy" and "degraded" for each service role. These map to Grafana alert rules and notification policies.
+
+Thresholds are initial defaults; tune per environment.
+
+#### Common log signals (for Loki)
+- Error spike: `level=error` count > 2 in 60s window → warn; > 5 → critical
+- Explicit health fail: `HEALTH_CHECK_FAIL` log presence → critical for the corresponding check
+- DB out of sync: log message containing `DB out of sync` → critical
+
+#### monitor (blockchain/indexer/monitor)
+- Unhealthy:
+  - Database connectivity check fails
+  - Chain RPC dependency check fails
+  - Queue lag > 120s for critical topics
+  - No blocks/events ingested in last 120s while expected
+  - Error logs > 5 in 60s
+- Degraded:
+  - Queue lag 30s–120s
+  - RPC latency p95 > 1500ms for 5m
+  - Error logs 3–5 in 60s
+  - Re-org rate spikes above baseline by 3x for 15m
+
+#### cron (scheduled tasks)
+- Unhealthy:
+  - Scheduler drift > 5m for any critical job
+  - Last successful run age > 2x schedule interval for critical jobs
+  - Database connectivity check fails
+  - Error logs > 5 in 60s
+- Degraded:
+  - Scheduler drift 2–5m
+  - Last successful run age between 1x–2x schedule interval
+  - Error logs 3–5 in 60s
+
+#### worker (queues/background processors)
+- Unhealthy:
+  - Queue backlog above `maxBacklogCritical` or oldest message age > 5m
+  - Dead-letter rate spikes above 5/min for 5m
+  - Database or cache connectivity fails
+  - Error logs > 5 in 60s
+- Degraded:
+  - Queue backlog above `maxBacklogWarn` or oldest message age 2–5m
+  - Dead-letter rate 1–5/min for 5m
+  - Error logs 3–5 in 60s
+
+#### server (API/web)
+- Unhealthy:
+  - Database connectivity fails
+  - p50 latency > 2s and p95 > 5s for 5m with RPS > 1
+  - 5xx rate > 2% for 5m with >= 50 requests total
+  - Error logs > 5 in 60s
+- Degraded:
+  - p95 latency 1–2s for 5m
+  - 5xx rate 0.5%–2% for 5m
+  - Error logs 3–5 in 60s
+
+#### Notes
+- All database-using services must include the `DatabaseConnectivityCheck` in readiness.
+- Use labels `service`, `env`, and `severity` in logs and metrics to power routing.
+- Where native metrics are missing, rely on log-based alerts temporarily.
+

--- a/observability/ref/python/healthsdk/health.py
+++ b/observability/ref/python/healthsdk/health.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field, asdict
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class HealthCheckResult:
+    name: str
+    componentType: str
+    status: str  # pass | fail | warn
+    severity: str  # critical | non_critical
+    observedValue: Any = None
+    expected: Any = None
+    timeMs: float = 0.0
+    output: Optional[str] = None
+
+
+def compute_overall_status(checks: List[HealthCheckResult]) -> str:
+    has_critical_fail = any(c.status == "fail" and c.severity == "critical" for c in checks)
+    if has_critical_fail:
+        return "unhealthy"
+    has_warn = any(c.status == "warn" for c in checks)
+    if has_warn:
+        return "degraded"
+    return "healthy"
+
+
+def summarize(checks: List[HealthCheckResult]) -> Dict[str, int]:
+    counts = {"pass": 0, "warn": 0, "fail": 0}
+    for c in checks:
+        counts[c.status] = counts.get(c.status, 0) + 1
+    return counts
+
+
+class HealthRegistry:
+    def __init__(self, service_name: str, version: Optional[Dict[str, Any]] = None):
+        self.service_name = service_name
+        self.version = version or {}
+        self._checks: List[Callable[[], HealthCheckResult]] = []
+
+    def register(self, check: Callable[[], HealthCheckResult]) -> None:
+        self._checks.append(check)
+
+    def evaluate(self) -> Dict[str, Any]:
+        results: List[HealthCheckResult] = []
+        for check in self._checks:
+            start = time.time()
+            try:
+                res = check()
+                res.timeMs = (time.time() - start) * 1000.0
+                results.append(res)
+            except Exception as exc:
+                results.append(
+                    HealthCheckResult(
+                        name=getattr(check, "__name__", "check"),
+                        componentType="other",
+                        status="fail",
+                        severity="critical",
+                        output=str(exc),
+                        timeMs=(time.time() - start) * 1000.0,
+                    )
+                )
+        overall = compute_overall_status(results)
+        return {
+            "service": self.service_name,
+            "status": overall,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "version": self.version,
+            "checks": [asdict(r) for r in results],
+            "summary": summarize(results),
+        }
+
+    def readiness_ok(self) -> bool:
+        report = self.evaluate()
+        for c in report["checks"]:
+            if c["severity"] == "critical" and c["status"] != "pass":
+                return False
+        return True
+
+
+def make_simple_check(
+    name: str,
+    component_type: str,
+    severity: str,
+    fn: Callable[[], Any],
+    validator: Optional[Callable[[Any], bool]] = None,
+    expected: Any = None,
+) -> Callable[[], HealthCheckResult]:
+    def _run() -> HealthCheckResult:
+        value = fn()
+        ok = validator(value) if validator else bool(value)
+        return HealthCheckResult(
+            name=name,
+            componentType=component_type,
+            status="pass" if ok else "fail",
+            severity=severity,
+            observedValue=value,
+            expected=expected,
+        )
+
+    _run.__name__ = name  # helpful for error reporting
+    return _run
+

--- a/observability/ref/python/requirements.txt
+++ b/observability/ref/python/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.2
+uvicorn==0.30.6

--- a/observability/ref/python/services/cron.py
+++ b/observability/ref/python/services/cron.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import time
+from fastapi import FastAPI, Response, status
+from healthsdk.health import HealthRegistry, make_simple_check
+
+
+app = FastAPI(title="cron")
+registry = HealthRegistry(service_name="cron", version={"gitSha": os.getenv("GIT_SHA", "dev")})
+
+
+LAST_SUCCESS = {"criticalJob": time.time()}
+SCHEDULE_SEC = {"criticalJob": 300}
+
+
+def db_ping():
+    return True
+
+
+def scheduler_drift():
+    now = time.time()
+    age = now - LAST_SUCCESS["criticalJob"]
+    return {"lastSuccessAgeSec": age}
+
+
+def validate_drift(v):
+    return v["lastSuccessAgeSec"] < 600
+
+
+registry.register(
+    make_simple_check(
+        name="database",
+        component_type="database",
+        severity="critical",
+        fn=db_ping,
+    )
+)
+
+registry.register(
+    make_simple_check(
+        name="schedulerDrift",
+        component_type="scheduler",
+        severity="critical",
+        fn=scheduler_drift,
+        validator=validate_drift,
+        expected={"lastSuccessAgeSecLt": 600},
+    )
+)
+
+
+@app.get("/health/live")
+def live():
+    return {"ok": True}
+
+
+@app.get("/health/ready")
+def ready(response: Response):
+    ok = registry.readiness_ok()
+    response.status_code = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    return {"ready": ok}
+
+
+@app.get("/health")
+def health(httpStatusFromStatus: bool = False, response: Response = None):
+    report = registry.evaluate()
+    if httpStatusFromStatus and response is not None:
+        if report["status"] == "healthy":
+            response.status_code = status.HTTP_200_OK
+        elif report["status"] == "degraded":
+            response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+        else:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return report
+

--- a/observability/ref/python/services/monitor.py
+++ b/observability/ref/python/services/monitor.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from fastapi import FastAPI, Response, status
+from healthsdk.health import HealthRegistry, make_simple_check
+
+
+app = FastAPI(title="monitor")
+registry = HealthRegistry(service_name="monitor", version={"gitSha": os.getenv("GIT_SHA", "dev")})
+
+
+def db_ping():
+    return True
+
+
+def rpc_head():
+    return {"reachable": True, "latencyMs": 100}
+
+
+def validate_rpc(v):
+    return v.get("reachable") and v.get("latencyMs", 10_000) < 1500
+
+
+registry.register(
+    make_simple_check(
+        name="database",
+        component_type="database",
+        severity="critical",
+        fn=db_ping,
+    )
+)
+
+registry.register(
+    make_simple_check(
+        name="chainRpc",
+        component_type="http",
+        severity="critical",
+        fn=rpc_head,
+        validator=validate_rpc,
+        expected={"latencyMsLt": 1500},
+    )
+)
+
+
+@app.get("/health/live")
+def live():
+    return {"ok": True}
+
+
+@app.get("/health/ready")
+def ready(response: Response):
+    ok = registry.readiness_ok()
+    response.status_code = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    return {"ready": ok}
+
+
+@app.get("/health")
+def health(httpStatusFromStatus: bool = False, response: Response = None):
+    report = registry.evaluate()
+    if httpStatusFromStatus and response is not None:
+        if report["status"] == "healthy":
+            response.status_code = status.HTTP_200_OK
+        elif report["status"] == "degraded":
+            response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+        else:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return report
+

--- a/observability/ref/python/services/server.py
+++ b/observability/ref/python/services/server.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from fastapi import FastAPI, Response, status
+from healthsdk.health import HealthRegistry, make_simple_check
+
+
+app = FastAPI(title="server")
+registry = HealthRegistry(service_name="server", version={"gitSha": os.getenv("GIT_SHA", "dev")})
+
+
+# Example checks (replace with real db/cache implementations)
+def db_ping():
+    return True  # Replace with SELECT 1
+
+
+def cache_ping():
+    return True
+
+
+registry.register(
+    make_simple_check(
+        name="database",
+        component_type="database",
+        severity="critical",
+        fn=db_ping,
+        expected={"latencyMsLt": 150},
+    )
+)
+
+registry.register(
+    make_simple_check(
+        name="redis",
+        component_type="cache",
+        severity="non_critical",
+        fn=cache_ping,
+        expected={"latencyMsLt": 100},
+    )
+)
+
+
+@app.get("/health/live")
+def live():
+    return {"ok": True}
+
+
+@app.get("/health/ready")
+def ready(response: Response):
+    ok = registry.readiness_ok()
+    response.status_code = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    return {"ready": ok}
+
+
+@app.get("/health")
+def health(httpStatusFromStatus: bool = False, response: Response = None):
+    report = registry.evaluate()
+    if httpStatusFromStatus and response is not None:
+        if report["status"] == "healthy":
+            response.status_code = status.HTTP_200_OK
+        elif report["status"] == "degraded":
+            response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+        else:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return report
+

--- a/observability/ref/python/services/worker.py
+++ b/observability/ref/python/services/worker.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from fastapi import FastAPI, Response, status
+from healthsdk.health import HealthRegistry, make_simple_check
+
+
+app = FastAPI(title="worker")
+registry = HealthRegistry(service_name="worker", version={"gitSha": os.getenv("GIT_SHA", "dev")})
+
+
+def db_ping():
+    return True
+
+
+def queue_depth():
+    # Replace with real queue query
+    return {"backlog": 0, "oldestAgeSec": 0}
+
+
+def validate_queue(value):
+    return value["backlog"] < 100 and value["oldestAgeSec"] < 300
+
+
+registry.register(
+    make_simple_check(
+        name="database",
+        component_type="database",
+        severity="critical",
+        fn=db_ping,
+    )
+)
+
+registry.register(
+    make_simple_check(
+        name="queueLag",
+        component_type="queue",
+        severity="critical",
+        fn=queue_depth,
+        validator=validate_queue,
+        expected={"backlogLt": 100, "oldestAgeSecLt": 300},
+    )
+)
+
+
+@app.get("/health/live")
+def live():
+    return {"ok": True}
+
+
+@app.get("/health/ready")
+def ready(response: Response):
+    ok = registry.readiness_ok()
+    response.status_code = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    return {"ready": ok}
+
+
+@app.get("/health")
+def health(httpStatusFromStatus: bool = False, response: Response = None):
+    report = registry.evaluate()
+    if httpStatusFromStatus and response is not None:
+        if report["status"] == "healthy":
+            response.status_code = status.HTTP_200_OK
+        elif report["status"] == "degraded":
+            response.status_code = status.HTTP_429_TOO_MANY_REQUESTS
+        else:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return report
+


### PR DESCRIPTION
Implement a health abstraction and define service-specific triggers to enable proactive monitoring and alerting.

This PR addresses Linear issue CRU-261 by providing a standardized health abstraction, defining "unhealthy" and "degraded" states for core services (monitor, cron, worker, server), and setting up initial Grafana alert rules and notification policies. It includes a Python reference SDK and example service implementations to demonstrate the new `/health`, `/health/live`, and `/health/ready` endpoints.

---
Linear Issue: [CRU-261](https://linear.app/crutrade/issue/CRU-261/define-unhealthy-for-each-service)

<a href="https://cursor.com/background-agent?bcId=bc-57c9a102-1fb9-4892-959b-3766ffefc9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57c9a102-1fb9-4892-959b-3766ffefc9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

